### PR TITLE
:bug: 아이폰 12 미니 실 기기에서 InAppMessage 닫기 버튼이 노치 영역에 가려지는 이슈 수정.

### DIFF
--- a/AppboyUI/ABKUIUtils/ABKUIUtils.m
+++ b/AppboyUI/ABKUIUtils/ABKUIUtils.m
@@ -2,11 +2,12 @@
 #import "ABKSDWebImageProxy.h"
 
 static NSString *const LocalizedAppboyStringNotFound = @"not found";
-static NSUInteger const iPhoneXHeight = 2436.0; // iPhone 12 mini is also this size
+static NSUInteger const iPhoneXHeight = 2436.0; // iPhone 12 mini(Simulator) is also this size
 static NSUInteger const iPhoneXRHeight = 1792.0;
 static NSUInteger const iPhoneXSMaxHeight = 2688.0;
 static NSUInteger const iPhoneXRScaledHeight = 1624.0;
 static NSUInteger const iPhone12 = 2532.0; // iPhone 12 pro is also this size
+static NSUInteger const iPhone12Mini = 2340.0; // iPhone 12 mini(Physical Device) is also this size
 static NSUInteger const iPhone12ProMax = 2778.0;
 
 // Bundles
@@ -219,6 +220,7 @@ static NSString * const ABKUIPodNFBundleName = @"AppboyUI.NewsFeed.bundle";
           [[UIScreen mainScreen] nativeBounds].size.height == iPhoneXSMaxHeight ||
           [[UIScreen mainScreen] nativeBounds].size.height == iPhoneXRScaledHeight ||
           [[UIScreen mainScreen] nativeBounds].size.height == iPhone12 ||
+          [[UIScreen mainScreen] nativeBounds].size.height == iPhone12Mini ||
           [[UIScreen mainScreen] nativeBounds].size.height == iPhone12ProMax);
 }
 


### PR DESCRIPTION
시뮬레이터와 실 기기의 해상도값이 다르게 들어오는 이슈가 있어, 이를 수정하는 PR 입니다.